### PR TITLE
Show auditable progress while real agent requests are waiting

### DIFF
--- a/backend/tests/unit/test_trace_progress_cli.py
+++ b/backend/tests/unit/test_trace_progress_cli.py
@@ -1,0 +1,21 @@
+"""Progress reads real files and never invents a successful execution state."""
+import json
+from pathlib import Path
+
+from scripts.watch_agent_trace import progress_snapshot
+
+
+def test_missing_trace_is_not_reported_as_completed(tmp_path: Path) -> None:
+    assert progress_snapshot(tmp_path) == []
+
+
+def test_unreadable_trace_remains_an_explicit_diagnostic(tmp_path: Path) -> None:
+    path = tmp_path / "agent_traces/idea/invocation/facts.json"
+    path.parent.mkdir(parents=True)
+    path.write_text('{"status":')
+    result = progress_snapshot(tmp_path)
+    assert result[0]["status"] == "unreadable"
+    assert result[0]["error_type"] == "JSONDecodeError"
+    # Incomplete metadata must also not be presented as a finished run.
+    path.write_text(json.dumps({"status": "passed"}))
+    assert progress_snapshot(tmp_path)[0]["status"] == "unreadable"

--- a/scripts/run_idea_lut_live.py
+++ b/scripts/run_idea_lut_live.py
@@ -11,6 +11,7 @@ import subprocess
 import sys
 import time
 import uuid
+from contextlib import suppress
 from dataclasses import asdict, replace
 from datetime import datetime, timezone
 from pathlib import Path
@@ -28,6 +29,7 @@ from app.harness.llm.model_registry import get_agent_config
 from app.harness.schema.validator import validate_document
 from app.settings import reset_settings_cache
 from scripts.idea_live_resume import exclusive_run, load_resume, record_resumption, resume_scenario
+from scripts.watch_agent_trace import monitor
 
 
 def git_value(*args: str) -> str:
@@ -134,6 +136,7 @@ async def _run(args: argparse.Namespace, root: Path) -> int:
         logger.info("prepared only; no model or tool request performed")
         return 0
     started = time.monotonic()
+    progress_task = asyncio.create_task(monitor(root))
     try:
         artifact = await asyncio.wait_for(agent.run_loop(request, context), timeout=args.max_seconds)
         target = root / "idea" / "idea_proposal.v1.md"
@@ -152,6 +155,9 @@ async def _run(args: argparse.Namespace, root: Path) -> int:
         summary.update(status="failed", error_type=type(exc).__name__, error=str(exc)[:1000])
         logger.error("real Idea run failed: {}", type(exc).__name__)
     finally:
+        progress_task.cancel()
+        with suppress(asyncio.CancelledError):
+            await progress_task
         summary["attempt_duration_seconds"] = time.monotonic() - started
         summary["duration_seconds"] = float(prior_summary.get("duration_seconds", 0)) + summary["attempt_duration_seconds"]
         summary["trace_root"] = context.metadata.get("loop_trace_root")

--- a/scripts/watch_agent_trace.py
+++ b/scripts/watch_agent_trace.py
@@ -1,0 +1,55 @@
+"""Show factual progress from an agent's on-disk trace without another API call."""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+from loguru import logger
+
+
+def progress_snapshot(run_root: Path) -> list[dict[str, Any]]:
+    snapshots: list[dict[str, Any]] = []
+    for path in sorted((run_root / "agent_traces").glob("*/*/facts.json")):
+        try:
+            facts = json.loads(path.read_text())
+            snapshots.append({
+                "agent": path.parent.parent.name, "invocation": path.parent.name,
+                "status": facts["status"], "waiting_for": facts.get("pending"),
+                "counts": facts["counts"], "usage_complete": facts["usage_complete"],
+                "seconds_since_trace_update": round(max(0.0, time.time() - path.stat().st_mtime), 1),
+            })
+        except (OSError, ValueError, KeyError, TypeError) as exc:
+            snapshots.append({"trace": str(path.parent), "status": "unreadable",
+                              "error_type": type(exc).__name__})
+    return snapshots
+
+
+async def monitor(run_root: Path, *, interval: float = 30.0) -> None:
+    while True:
+        snapshots = progress_snapshot(run_root)
+        logger.info("AGENT_PROGRESS {}", json.dumps(snapshots or [{"status": "starting"}], ensure_ascii=False))
+        await asyncio.sleep(interval)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("run_root", type=Path)
+    parser.add_argument("--once", action="store_true")
+    args = parser.parse_args()
+    if not args.run_root.is_dir():
+        parser.error("run_root must be an existing run directory")
+    if args.once:
+        logger.info("AGENT_PROGRESS {}", json.dumps(progress_snapshot(args.run_root), ensure_ascii=False))
+    else:
+        try:
+            asyncio.run(monitor(args.run_root))
+        except KeyboardInterrupt:
+            pass
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Long provider requests previously left the headless CLI silent until completion. This adds a 30-second progress report from actual on-disk trace facts: agent/invocation, pending model or tool, cumulative counters and age of the latest trace update. The watcher can also inspect an existing run without another API call.

No result, model response or reasoning content is invented or displayed by the watcher. Missing/corrupt traces remain explicit diagnostics. Six relevant CLI/resumption checks passed; strict Python 3.11 mypy passed 406 source files. The earlier full runtime changes are already merged in PR #5. Real Idea evaluation continues with its original input/source history.