### PR TITLE
Isolate public Idea evaluation context and clarify persisted progress

### DIFF
--- a/backend/app/agents/base.py
+++ b/backend/app/agents/base.py
@@ -96,6 +96,12 @@ class BaseAgent(ABC):
 
     async def build_context(self, request: RunRequest) -> ContextPack:
         from app.storage.agent_context_store import load_agent_code_repositories
+        sources = {"project_rules": True, "code_repositories": True}
+        configured = request.extra.get("context_sources", {})
+        if (not isinstance(configured, dict) or set(configured) - set(sources)
+                or any(not isinstance(value, bool) for value in configured.values())):
+            raise ValueError("context_sources accepts only project_rules/code_repositories booleans")
+        sources.update(configured)
         required = request.extra.get("required_upstream_refs", [])
         if not isinstance(required, list) or any(x not in request.upstream_artifacts for x in required):
             raise ValueError("required_upstream_refs must name supplied upstream artifacts")
@@ -103,10 +109,12 @@ class BaseAgent(ABC):
         if not project_path.resolve().is_relative_to((repo_root() / "projects").resolve()):
             raise ValueError("invalid project path")
         rules_path = project_path / "AGENTS.md"
-        rules = rules_path.read_text() if rules_path.is_file() else "No project-specific rules supplied."
-        repositories = load_agent_code_repositories(self.name, project=request.project)
+        rules = (rules_path.read_text() if sources["project_rules"] and rules_path.is_file()
+                 else "No project-specific rules supplied in this context.")
+        repositories = (load_agent_code_repositories(self.name, project=request.project)
+                        if sources["code_repositories"] else ())
         upstream = dict(request.upstream_artifacts)
-        metadata: dict[str, Any] = {"required_upstream_refs": required}
+        metadata: dict[str, Any] = {"required_upstream_refs": required, "context_sources": sources}
         if repositories:
             upstream[f"{self.name}_code_repositories"] = json.dumps(
                 [asdict(repository) for repository in repositories], ensure_ascii=False)

--- a/backend/tests/unit/test_public_research_context.py
+++ b/backend/tests/unit/test_public_research_context.py
@@ -1,0 +1,50 @@
+"""Real context construction for an isolated public-literature evaluation."""
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+import yaml
+
+from app.agents.base import RunRequest
+from app.agents.idea.agent import IdeaAgent
+from app.harness.llm.model_registry import get_agent_config
+from app.harness.tools.registry import get_registry
+from app.settings import repo_root
+from scripts.run_idea_lut_live import PUBLIC_RESEARCH_TOOLS, evaluation_request
+
+
+@pytest.mark.asyncio
+async def test_public_evaluation_excludes_real_project_rules_and_repository_metadata(tmp_path: Path) -> None:
+    scenario = yaml.safe_load((repo_root() / "configs/evaluation/idea_2d_lut_real.yaml").read_text())
+    request = evaluation_request(scenario, tmp_path)
+    agent = IdeaAgent(agent_config=replace(get_agent_config("idea"), tools=PUBLIC_RESEARCH_TOOLS))
+    context = await agent.build_context(request)
+    assert not context.upstream
+    assert context.metadata["context_sources"] == {"project_rules": False, "code_repositories": False}
+    assert "No project-specific rules supplied" in context.project
+    assert context.task.startswith(scenario["question"])
+    original = await agent.build_context(RunRequest(project="pimc", user_request="Authored context comparison"))
+    assert original.project != context.project
+    assert "idea_code_repositories" in original.upstream
+    assert not request.upstream_artifacts
+    for name in agent.config.tools:
+        spec = get_registry().spec(name)
+        assert spec is not None and spec.policy.mutation_level == "read"
+    assert "code.repo_reader" not in agent.config.tools
+    assert "search.local_docs" not in agent.config.tools
+    assert "knowledge.baseline_match" not in agent.config.tools
+
+
+@pytest.mark.parametrize("sources", [{"project_rules": "false"}, {"unknown": False}, []])
+@pytest.mark.asyncio
+async def test_invalid_context_selection_fails_before_provider_use(sources: object) -> None:
+    with pytest.raises(ValueError, match="context_sources"):
+        await IdeaAgent().build_context(RunRequest(project="pimc", user_request="Authored invalid configuration",
+                                                   extra={"context_sources": sources}))
+
+
+def test_legacy_or_project_input_cannot_silently_resume_as_public(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="legacy inputs"):
+        evaluation_request({"scope": "method_proposal"}, tmp_path)
+    with pytest.raises(ValueError, match="method_proposal"):
+        evaluation_request({"scope": "project_proposal", "data_scope": "public_research"}, tmp_path)

--- a/configs/evaluation/idea_2d_lut_real.yaml
+++ b/configs/evaluation/idea_2d_lut_real.yaml
@@ -1,5 +1,6 @@
 project: pimc
 scope: method_proposal
+data_scope: public_research
 question: |
   为 PIMC 非线性层提出一个改善 2D LUT 非线性表达能力、且参数量不大幅膨胀的可实现方案。
   自主查询真实 Memory 和允许网站上的文献；根据实际返回内容选择至少两篇相关论文，

--- a/docs/idea_live_review_20260907.md
+++ b/docs/idea_live_review_20260907.md
@@ -235,3 +235,35 @@ GitHub PR #5 的首个 CI 在创建任何 job 之前失败。GitHub 原始 annot
 实际安装依赖的 Python 3.11 strict mypy 检查 403 文件通过。完整测试启用了真实 Chroma 后发现旧正向样例缺来源回执；已改用真实本地文件回执，并修复多 KB 实例错误依赖全局 KB 路径的问题。每个 File/Chroma backend 现在只信任本实例根目录下的回执，测试明确拒绝跨库复制的回执；22 个相关检查通过。
 
 Windows 原测试覆盖了伪 Docker 返回，已移除替身。保留实际临时文件、配置/端口/路径/校验和与纯 readiness DTO 校验（这些不冒充容器或 API 执行）。实际 CI 进一步发现 Windows compose/env 仍默认 auto/mock、Dockerfile 引用已不存在的 stub；已改为 never/local_command，未接入研究仓库时使用缺失的明确路径并阻塞执行，删除 stub COPY。Compose config 新版本省略 false 字段，测试同时保留源 YAML 约束并按 false 缺省读取输出，未放宽挂载保护。
+
+### main 已交付与外部中断（2026-09-07）
+
+核心修复 PR #5 的四个真实 GitHub CI job 全部通过，已合入 main `162a304`。
+Python 3.11 完整回归实际 910 项：902 通过、8 跳过、无失败；包含真实 Chroma。
+进度显示 PR #6 同样通过四个 CI job，合入 main `6c5cad2`。
+CLI 每 30 秒显示实际请求、工具、修订计数与最后 trace 更新时间；
+`scripts/watch_agent_trace.py RUN_ROOT --once` 可以只读查看已有 run。
+磁盘状态不是进程存活证明，待处理请求的用量也不算完整。
+
+新 run `idea_lut_20260907T102414_f65c68` 在第 12 个模型请求被宿主自动审批中断：
+审批认为外发上下文可能包含未授权的私有仓库或 Memory 内容。不得换传输或修改原始
+checkpoint 绕过；原 summary 仍为 prepared，trace 的最后状态 running 也不是已完成。
+实际已记录 11 次响应、6 次工具/Observation、3 次协议修复、1 次拒绝的 Reflection，
+147462 已报告 tokens；被中断请求的最终用量未知。
+
+实际操作：一次 literature Memory 查询为空；四次 arXiv 检索（两次为空，另两次各 10 条）；
+一次批量下载两篇 PDF：Free-Knots KAN（2442172 字节）与 MP-DPD（1374338 字节）。
+两篇均实际返回第 1–2 页及截断的第 3 页，不能称读完全文或完整前四页。
+独立数值检查证实候选 33×33 复数 LUT 加 13×13 复数修正表的 2516/2178=1.1552
+实标量预算、零修正保持基线、边界连续及存在新增函数。符号例的 128×128 网格拟合
+RMSE 从 0.058285 降至 0.044173；这是审查者检查，不是 Agent 实验，也不是 PIMC 效果。
+候选的消融判定、索引与阅读表述仍需修订，未记录最终验收通过。
+
+核对实际数据来源后，GitHub 仓库为公开仓库，附带的路径来自公开 repo_link 配置；
+工具未读取生产代码，Memory 查询没有历史命中。即便如此，方法评测携带这份配置
+没有必要。现增加严格布尔型 context_sources，普通子 Agent 仍保留项目上下文；
+本 CLI 使用 public_research 范围，关闭项目规则和代码仓注入，只开放 kb_query、
+arxiv_search、web_search、fetch_sources，并使用每轮独立的 Memory 与检索缓存。
+不读取上传文件，不静默更改旧 run 的输入/工具指纹；旧范围须新建评测。
+新范围的准备检查没有发送请求；26 项相关真实上下文/文件/拒绝请求检查通过，
+涉及 271 个源文件的 strict mypy 通过。实际新的模型结果另行记录。

--- a/scripts/run_idea_lut_live.py
+++ b/scripts/run_idea_lut_live.py
@@ -32,6 +32,27 @@ from scripts.idea_live_resume import exclusive_run, load_resume, record_resumpti
 from scripts.watch_agent_trace import monitor
 
 
+PUBLIC_RESEARCH_TOOLS = (
+    "knowledge.kb_query", "search.arxiv_search", "search.web_search", "search.fetch_sources",
+)
+
+
+def evaluation_request(scenario: dict[str, Any], root: Path) -> RunRequest:
+    """Method-only evaluation never imports project rules, linked repos or uploads.
+
+    The supplied question remains caller-owned input. The CLI selects a fresh KB
+    per run; only its actual public-source retrievals can populate that memory.
+    Old runs with a different data scope cannot silently acquire new inputs.
+    """
+    if scenario.get("data_scope") != "public_research" or scenario.get("scope") != "method_proposal":
+        raise ValueError("this CLI requires a public_research method_proposal scenario; "
+                         "legacy inputs need a new evaluation, not a changed resume")
+    return RunRequest(project=scenario["project"], user_request=scenario["question"],
+                      extra={"run_id": root.name, "run_root": str(root), "scope": scenario["scope"],
+                             "idea_requirements": scenario["requirements"],
+                             "context_sources": {"project_rules": False, "code_repositories": False}})
+
+
 def git_value(*args: str) -> str:
     return subprocess.check_output(["git", *args], text=True).strip()
 
@@ -67,6 +88,7 @@ async def _run(args: argparse.Namespace, root: Path) -> int:
         scenario = yaml.safe_load(args.scenario.read_text())
     if not isinstance(scenario, dict):
         raise ValueError("scenario must be an object")
+    request = evaluation_request(scenario, root)
     if args.prompt_key:
         key = getpass.getpass("Zhipu API key (hidden, not saved): ")
         if not key:
@@ -98,11 +120,9 @@ async def _run(args: argparse.Namespace, root: Path) -> int:
                      max_tokens=int(model["max_tokens"]), temperature=float(model["temperature"]),
                      thinking_enabled=bool(model.get("thinking", True)), reasoning_effort=model.get("reasoning_effort"),
                      request_timeout_seconds=float(model["timeout_seconds"]), max_retries=int(model["max_retries"]),
-                     debate_enabled=False, raw={**original.raw, "loop": asdict(policy)})
+                     debate_enabled=False, tools=PUBLIC_RESEARCH_TOOLS,
+                     raw={**original.raw, "loop": asdict(policy)})
     agent = IdeaAgent(agent_config=config)
-    request = RunRequest(project=scenario["project"], user_request=scenario["question"],
-                         extra={"run_id": run_id, "run_root": str(root), "scope": scenario["scope"],
-                                "idea_requirements": scenario["requirements"]})
     if checkpoint:
         request.extra["resume_invocation"] = checkpoint.parent.name
     if review:
@@ -121,7 +141,10 @@ async def _run(args: argparse.Namespace, root: Path) -> int:
         initial = {"run_id": run_id, **source,
                "scenario": scenario, "loop_policy": asdict(policy),
                "messages": [asdict(m) for m in messages],
-               "scope": scenario["scope"], "credential_persisted": False}
+               "scope": scenario["scope"], "credential_persisted": False,
+               "data_scope": {"profile": "public_research", "tools": list(config.tools),
+                              "context_sources": context.metadata["context_sources"],
+                              "memory": "isolated_run_directory", "upstream_artifacts": []}}
         atomic_json(root / "input" / "request.json", initial)
     summary: dict[str, Any] = {"run_id": run_id, "run_root": str(root), "status": "prepared",
                                "source_commit": initial["source_commit"], "source_dirty": initial["source_dirty"],

--- a/scripts/watch_agent_trace.py
+++ b/scripts/watch_agent_trace.py
@@ -19,7 +19,9 @@ def progress_snapshot(run_root: Path) -> list[dict[str, Any]]:
             snapshots.append({
                 "agent": path.parent.parent.name, "invocation": path.parent.name,
                 "status": facts["status"], "waiting_for": facts.get("pending"),
-                "counts": facts["counts"], "usage_complete": facts["usage_complete"],
+                "counts": facts["counts"],
+                "usage_complete": bool(facts["usage_complete"]) and facts.get("pending") != "model",
+                "state_source": "last_persisted_trace", "process_liveness": "unknown",
                 "seconds_since_trace_update": round(max(0.0, time.time() - path.stat().st_mtime), 1),
             })
         except (OSError, ValueError, KeyError, TypeError) as exc:


### PR DESCRIPTION
The method-only live evaluation unnecessarily inherited project repository metadata and exposed tools for uploaded documents and baseline access. An external approval review interrupted a live request over possible private context disclosure.

Add validated per-request context source selection in BaseAgent. Normal agents keep project context; the public literature CLI excludes project rules/repositories and permits only isolated memory queries, public search and source downloads. Legacy run fingerprints are not changed or replayed. The caller's question remains explicit input.

Progress snapshots now state that they show the last persisted trace, cannot prove process liveness, and do not count an outstanding model request's usage as complete. Preserve the externally interrupted run as an incomplete attempt; document actual actions and numerical review separately from scientific acceptance.

Validation: 26 targeted tests passed using real context, files and connection-refusal behavior; strict Python 3.11 mypy passed on 271 affected source files. New public-scope live Zhipu evaluation is running; no success is claimed in advance. Core and progress changes in PRs #5/#6 are already merged into main with all four CI jobs passed.