### PR TITLE
Preserve Idea repair context and report exact versions and provider failures

### DIFF
--- a/backend/app/harness/agent_loop/executor.py
+++ b/backend/app/harness/agent_loop/executor.py
@@ -11,7 +11,7 @@ from typing import Any, Protocol
 from app.harness.agent_loop.context import pack_context
 from app.harness.agent_loop.policy import AgentLoopPolicy
 from app.harness.agent_loop.review import ExternalReview, review_revision
-from app.harness.agent_loop.protocol import INSTRUCTION, ReviewConflictError, parse_action, parse_review
+from app.harness.agent_loop.protocol import INSTRUCTION, ReviewConflictError, invalid_output_context, parse_action, parse_review
 from app.harness.agent_loop.trace import LoopTrace, atomic_json, canonical, digest
 from app.harness.llm.provider_base import LLMCompletionError, LLMConfig, LLMProvider, Message, llm_call_deadline_seconds
 from app.harness.tools.registry import ToolContext, ToolRegistry
@@ -102,6 +102,7 @@ class NativeAgentLoop:
             state["status"] = "running"
             state["pending"] = None
         state.setdefault("review_issues", [])
+        state.setdefault("protocol_output", "")
         state.setdefault("reviewed_candidate_sha", "")
         state.setdefault("phase_efforts", {})
         if request.resume and "last_model_error" not in state:
@@ -167,6 +168,8 @@ class NativeAgentLoop:
             for _ in range(max(0, p.max_model_calls - counts["model_requests"])):
                 reviewing = state["next_phase"] == "reflect"
                 extra: list[Message] = []
+                if state["protocol_output"]:
+                    extra.append(invalid_output_context(state["protocol_output"]))
                 if state["review_issues"]:
                     extra.append(Message(role="user", content=(
                         "[unresolved review issues pinned through protocol/schema repairs]\n"
@@ -231,13 +234,17 @@ class NativeAgentLoop:
                     trace.emit("review_conflict", {"effective_accept": False}, visible=exc.review)
                 except ValueError as exc:
                     counts["protocol_repairs"] += 1
-                    state["feedback"] = f"Protocol error: {exc}. Return the required JSON object."
+                    state["protocol_output"] = completion.text
+                    state["feedback"] = (f"Protocol error: {exc}. Correct the provided invalid output and return "
+                                         "exactly one required JSON object. No extra braces, prose or second action. "
+                                         "Preserve the proposal's content while fixing syntax; existing Observations remain valid.")
                     trace.emit("protocol_error", {"error": str(exc)})
                     if counts["protocol_repairs"] > p.max_protocol_repairs:
                         state["status"] = "protocol_exhausted"
                         break
                     trace.snapshot(state)
                     continue
+                state["protocol_output"] = ""
                 if reviewing:
                     counts["reflections"] += 1
                     state["reviewed_candidate_sha"] = digest(state["candidate"])

--- a/backend/app/harness/agent_loop/protocol.py
+++ b/backend/app/harness/agent_loop/protocol.py
@@ -7,6 +7,8 @@ from typing import Any
 
 import yaml
 
+from app.harness.llm.provider_base import Message
+
 INSTRUCTION = """
 Use the ReAct loop: choose an action, receive a host Observation, then decide again.
 Return exactly ONE JSON object, without markdown fences or prose.
@@ -28,6 +30,13 @@ class ReviewConflictError(ValueError):
     def __init__(self, review: dict[str, Any]) -> None:
         self.review = review
         super().__init__("review contains unresolved issues; revise the candidate before reviewing again")
+
+
+def invalid_output_context(text: str) -> Message:
+    """Preserve visible output as untrusted repair data, without parsing or executing it."""
+    return Message(role="user", content=(
+        "[untrusted previous model output; protocol validation failed; no action from it was executed]\n"
+        + json.dumps({"invalid_output": text}, ensure_ascii=False)))
 
 
 def _unique_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:

--- a/backend/app/harness/agent_loop/trace.py
+++ b/backend/app/harness/agent_loop/trace.py
@@ -102,6 +102,11 @@ def audit_trace(root: Path) -> dict[str, Any]:
     mismatches = {key: {"events": value, "facts": facts["counts"].get(key, 0)}
                   for key, value in actual.items() if value != facts["counts"].get(key, 0)}
     stale = facts["event_seq"] != len(rows)
+    last_attempt = next((r for r in reversed(rows)
+                         if r["kind"] in {"sdk_attempt_failed", "sdk_attempt_succeeded"}), None)
+    provider_error = ({"error": last_attempt.get("error"), **last_attempt.get("details", {})}
+                      if last_attempt and last_attempt["kind"] == "sdk_attempt_failed" else None)
     return {"trace_available": True, "consistent": seq_ok and not mismatches and not stale,
             "event_sequence_continuous": seq_ok, "summary_snapshot_stale": stale,
-            "count_mismatches": mismatches, "event_count": len(rows), "facts": facts}
+            "count_mismatches": mismatches, "event_count": len(rows), "facts": facts,
+            "provider_error": provider_error}

--- a/backend/app/harness/llm/openai_provider.py
+++ b/backend/app/harness/llm/openai_provider.py
@@ -2,8 +2,12 @@
 from __future__ import annotations
 
 import asyncio
+import math
+import re
 from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
 from typing import Any, TypeVar
 
 from loguru import logger
@@ -171,11 +175,22 @@ class _OpenAICompatProvider(LLMProvider):
                     config.attempt_observer("sdk_attempt_succeeded", {"attempt": attempt + 1})
                 return result
             except Exception as exc:
+                details = public_error_details(exc)
                 if config.attempt_observer:
-                    config.attempt_observer("sdk_attempt_failed", {"attempt": attempt + 1, "error": _safe_error_label(exc)})
-                if attempt >= max_retries or not _is_retryable_error(exc):
+                    config.attempt_observer("sdk_attempt_failed", {"attempt": attempt + 1,
+                                                                  "error": _safe_error_label(exc), "details": details})
+                if attempt >= max_retries or not _is_retryable_error(exc, provider_name=self.name):
                     raise
                 delay = base_delay * (2**attempt)
+                if details.get("retry_after_seconds", 0) > delay:
+                    # Do not retry earlier than the provider requested or extend
+                    # the caller's configured backoff/deadline behind its back.
+                    if config.attempt_observer:
+                        config.attempt_observer("sdk_retry_deferred", {
+                            "reason": "provider Retry-After exceeds this call's backoff budget",
+                            "retry_after_seconds": details["retry_after_seconds"],
+                        })
+                    raise
                 if config.attempt_observer:
                     config.attempt_observer("sdk_retry_scheduled", {"next_attempt": attempt + 2, "delay": delay})
                 logger.warning(
@@ -398,7 +413,52 @@ def _status_code(exc: Exception) -> int | None:
     return response_status if isinstance(response_status, int) else None
 
 
-def _is_retryable_error(exc: Exception) -> bool:
+def retry_after_seconds(value: object, *, now: datetime | None = None) -> float | None:
+    if not isinstance(value, str):
+        return None
+    try:
+        seconds = float(value)
+    except ValueError:
+        try:
+            target = parsedate_to_datetime(value)
+            if target.tzinfo is None:
+                return None
+            seconds = (target - (now or datetime.now(timezone.utc))).total_seconds()
+        except (ValueError, TypeError, OverflowError):
+            return None
+    return max(0.0, seconds) if math.isfinite(seconds) else None
+
+
+def public_error_details(exc: Exception) -> dict[str, Any]:
+    """Only bounded codes and Retry-After; never response messages, bodies or auth headers."""
+    details: dict[str, Any] = {"exception_type": type(exc).__name__}
+    status = _status_code(exc)
+    if status is not None:
+        details["http_status"] = status
+    body = getattr(exc, "body", None)
+    error = body.get("error", body) if isinstance(body, Mapping) else {}
+    code = error.get("code") if isinstance(error, Mapping) else None
+    if code is None:
+        code = getattr(exc, "code", None)
+    if type(code) in {str, int} and re.fullmatch(r"(?:[0-9]{1,8}|[a-z][a-z0-9_]{0,63})", str(code)):
+        details["api_error_code"] = str(code)
+    headers = getattr(getattr(exc, "response", None), "headers", None)
+    delay = retry_after_seconds(headers.get("retry-after")) if isinstance(headers, Mapping) else None
+    if delay is not None:
+        details["retry_after_seconds"] = delay
+    return details
+
+
+def _is_retryable_error(exc: Exception, *, provider_name: str = "") -> bool:
+    code = public_error_details(exc).get("api_error_code")
+    if code in {"insufficient_quota", "billing_hard_limit_reached"}:
+        return False
+    # Official BigModel account/quota/access errors also use HTTP 429.
+    if provider_name == "zhipu" and code in {
+        "1113", "1304", "1308", "1309", "1310", "1311", "1313", "1314", "1315",
+        "1316", "1317", "1318", "1319", "1320", "1321",
+    }:
+        return False
     if isinstance(exc, (TimeoutError, asyncio.TimeoutError)):
         return True
 
@@ -431,6 +491,8 @@ def _is_retryable_error(exc: Exception) -> bool:
 
 def _safe_error_label(exc: Exception) -> str:
     status_code = _status_code(exc)
+    code = public_error_details(exc).get("api_error_code")
+    suffix = f":code={code}" if code is not None else ""
     if status_code is not None:
-        return f"{type(exc).__name__}:status={status_code}"
+        return f"{type(exc).__name__}:status={status_code}{suffix}"
     return type(exc).__name__

--- a/backend/app/harness/llm/openai_provider.py
+++ b/backend/app/harness/llm/openai_provider.py
@@ -180,6 +180,8 @@ class _OpenAICompatProvider(LLMProvider):
                     config.attempt_observer("sdk_attempt_failed", {"attempt": attempt + 1,
                                                                   "error": _safe_error_label(exc), "details": details})
                 if attempt >= max_retries or not _is_retryable_error(exc, provider_name=self.name):
+                    logger.error("LLM request stopped provider={} model={} reason={}",
+                                 self.name, config.model, _safe_error_label(exc))
                     raise
                 delay = base_delay * (2**attempt)
                 if details.get("retry_after_seconds", 0) > delay:
@@ -190,6 +192,8 @@ class _OpenAICompatProvider(LLMProvider):
                             "reason": "provider Retry-After exceeds this call's backoff budget",
                             "retry_after_seconds": details["retry_after_seconds"],
                         })
+                    logger.error("LLM retry deferred provider={} model={} retry_after_seconds={}",
+                                 self.name, config.model, details["retry_after_seconds"])
                     raise
                 if config.attempt_observer:
                     config.attempt_observer("sdk_retry_scheduled", {"next_attempt": attempt + 2, "delay": delay})

--- a/backend/tests/unit/test_idea_audit_versions.py
+++ b/backend/tests/unit/test_idea_audit_versions.py
@@ -1,0 +1,26 @@
+"""Version selection on real local files, without model execution substitutes."""
+from pathlib import Path
+
+import pytest
+
+from scripts.audit_idea_run import recorded_proposal
+
+
+def test_audit_selects_recorded_version_and_never_falls_back_when_missing(tmp_path: Path) -> None:
+    idea = tmp_path / "idea"
+    idea.mkdir()
+    first, second = idea / "idea_proposal.v1.md", idea / "idea_proposal.v2.md"
+    first.write_text("Human-authored older file for a path-selection check")
+    second.write_text("Human-authored newer file for a path-selection check")
+    assert recorded_proposal(tmp_path, {"proposal_path": str(second)}) == second
+    assert recorded_proposal(tmp_path, {"proposal_path": "idea/idea_proposal.v2.md"}) == second
+    second.unlink()
+    assert recorded_proposal(tmp_path, {"proposal_path": str(second)}) == second
+    assert not recorded_proposal(tmp_path, {"proposal_path": str(second)}).exists()
+    assert recorded_proposal(tmp_path, {}) == first
+
+
+@pytest.mark.parametrize("path", ["../other/idea_proposal.v2.md", "summary.json", "idea/idea_proposal.v0.md", ""])
+def test_audit_rejects_outside_or_unversioned_proposal_paths(tmp_path: Path, path: str) -> None:
+    with pytest.raises(ValueError, match="proposal"):
+        recorded_proposal(tmp_path, {"proposal_path": path})

--- a/backend/tests/unit/test_idea_live_resume.py
+++ b/backend/tests/unit/test_idea_live_resume.py
@@ -10,7 +10,7 @@ import pytest
 
 from app.agents.base import RunRequest
 from app.agents.idea.agent import IdeaAgent
-from app.harness.agent_loop.trace import atomic_json
+from app.harness.agent_loop.trace import atomic_json, audit_trace
 from app.harness.llm.model_registry import get_agent_config
 from scripts.idea_live_resume import audit_resumptions, exclusive_run, load_resume, record_resumption, resume_scenario
 
@@ -54,6 +54,9 @@ async def test_real_failed_request_resume_retains_counters_and_verifiable_source
     assert after["counts"]["model_requests"] == after["counts"]["sdk_attempts"] == 2
     assert after["counts"]["model_responses"] == 0 and after["candidate"] == ""
     assert after["usage_complete"] is False
+    diagnosis = audit_trace(checkpoint.parent)["provider_error"]
+    assert diagnosis["exception_type"] == "APIConnectionError"
+    assert "transport-contract-not-a-credential" not in json.dumps(diagnosis)
     rows, errors = audit_resumptions(tmp_path, checkpoint.parent)
     assert len(rows) == 1 and not errors
     # Real disk tampering must invalidate the preserved evidence.

--- a/backend/tests/unit/test_protocol_repair_context.py
+++ b/backend/tests/unit/test_protocol_repair_context.py
@@ -1,0 +1,33 @@
+"""Raw syntax-repair context contracts; no successful model response is substituted."""
+import json
+
+import pytest
+
+from app.harness.agent_loop.context import pack_context
+from app.harness.agent_loop.protocol import invalid_output_context, parse_action
+from app.harness.llm.provider_base import Message
+
+
+def test_unparsed_output_is_preserved_as_data_with_candidate_and_review() -> None:
+    raw = '{"final":{"metadata":{"authored_text":"quoted\\value"},"body":"unterminated'
+    message = invalid_output_context(raw)
+    assert message.role == "user"
+    assert json.loads(message.content.split("\n", 1)[1])["invalid_output"] == raw
+    with pytest.raises(ValueError):
+        parse_action(raw)
+    with pytest.raises(ValueError):
+        parse_action(message.content)
+    candidate = "Human-authored previous candidate for a context serialization test"
+    messages, manifest = pack_context([Message("system", "Schema contract"), message], [],
+                                      "Keep the unresolved boundary issue", candidate,
+                                      budget=5000, observation_chars=1000)
+    assert messages[1] == message
+    assert json.loads(messages[-2].content)["candidate"] == candidate
+    assert "unresolved boundary issue" in messages[-1].content
+    assert not manifest["omitted_history"]
+
+
+def test_oversized_invalid_output_is_not_silently_dropped() -> None:
+    message = invalid_output_context("Authored raw text" * 500)
+    with pytest.raises(ValueError, match="nothing was silently dropped"):
+        pack_context([message], [], "Fix JSON syntax", "", budget=1000, observation_chars=500)

--- a/backend/tests/unit/test_provider_error_diagnostics.py
+++ b/backend/tests/unit/test_provider_error_diagnostics.py
@@ -1,0 +1,36 @@
+"""Classify authored SDK exception values; no transport receives a substitute response."""
+from datetime import datetime, timezone
+from typing import Any, cast
+
+import httpx
+import pytest
+from openai import APIStatusError
+
+from app.harness.llm.openai_provider import _is_retryable_error, public_error_details, retry_after_seconds
+
+
+@pytest.mark.parametrize("code,retryable", [("1113", False), ("1308", False), ("1310", False),
+                                            ("1313", False), ("1315", False), ("1302", True), ("1305", True)])
+def test_account_limits_are_distinct_from_transient_429(code: str, retryable: bool) -> None:
+    response = httpx.Response(429, request=httpx.Request("POST", "https://example.invalid"),
+                              headers={"retry-after": "30", "authorization": "authored-private-header"})
+    error = APIStatusError("authored error-classifier input", response=cast(Any, response),
+                           body={"error": {"code": code, "message": "authored-private-response-message"}})
+    assert _is_retryable_error(error, provider_name="zhipu") is retryable
+    assert public_error_details(error) == {"exception_type": "APIStatusError", "http_status": 429,
+                                           "api_error_code": code, "retry_after_seconds": 30.0}
+
+
+def test_unrecognized_body_values_do_not_escape_into_diagnostics() -> None:
+    response = httpx.Response(429, request=httpx.Request("POST", "https://example.invalid"))
+    error = APIStatusError("authored private message", response=cast(Any, response),
+                           body={"error": {"code": "authored.secret-shaped-value", "message": "private"}})
+    assert public_error_details(error) == {"exception_type": "APIStatusError", "http_status": 429}
+
+
+def test_retry_after_supports_seconds_and_http_dates_and_rejects_nonfinite_values() -> None:
+    assert retry_after_seconds("30") == 30
+    now = datetime(2026, 9, 7, 0, 0, tzinfo=timezone.utc)
+    assert retry_after_seconds("Mon, 07 Sep 2026 00:00:30 GMT", now=now) == 30
+    for value in [None, "nan", "inf", "invalid date"]:
+        assert retry_after_seconds(value) is None

--- a/configs/evaluation/idea_2d_lut_public_urls_real.yaml
+++ b/configs/evaluation/idea_2d_lut_public_urls_real.yaml
@@ -1,0 +1,66 @@
+project: pimc
+scope: method_proposal
+data_scope: public_research
+question: '为 PIMC 非线性层提出一个改善 2D LUT 非线性表达能力、且参数量不大幅膨胀的可实现方案。
+
+  自主查询真实 Memory 和允许网站上的文献；根据实际返回内容选择至少两篇相关论文，
+
+  说明为何相关；至少下载一篇 PDF 并读取含方法定义的页段，必要时追加页窗口。
+
+  比较至少两个可行方向后选择一个，完整定义参考 LUT、候选公式、输入输出与相位契约、
+
+  全部可训练量、初始化、边界处理和训练方式，设计公平消融、证伪和停止标准。
+
+  本测试没有接入项目真实基线、数据或 GPU；可以定义符号化参考模型，但不能伪装已读生产代码。
+
+  参数量上限 1.2 倍仅为本次评测假设，最终效果未做实验验证。请中文输出。
+
+
+  以下是前次真实检索取得的公开线索，可作为调研起点；仍需用工具核对原文，自主决定是否采用，不能仅凭链接声称已经读过：
+
+  - Gradient-Adaptive Spline-Interpolated LUT Methods for Low-Complexity Digital Predistortion:
+  https://arxiv.org/abs/1907.02350v4
+
+  - Free-Knots Kolmogorov-Arnold Network: On the Analysis of Spline Knots and Advancing
+  Stability: https://arxiv.org/abs/2501.09283v1
+
+  '
+model:
+  provider: zhipu
+  name: glm-5.3
+  max_tokens: 16384
+  temperature: 0.1
+  thinking: true
+  reasoning_effort: low
+  timeout_seconds: 300
+  max_retries: 1
+loop:
+  mode: reflection
+  reflection_reasoning_effort: high
+  trace: full
+  max_model_calls: 32
+  max_tool_steps: 18
+  max_protocol_repairs: 4
+  max_validation_repairs: 6
+  max_reflections: 4
+  input_token_budget: 64000
+  observation_chars: 6000
+requirements:
+  min_sources: 2
+  min_pdfs: 1
+  require_parameter_budget: true
+  max_parameter_ratio: 1.2
+domains:
+- arxiv.org
+- export.arxiv.org
+- ieeexplore.ieee.org
+- doi.org
+- openreview.net
+evaluation_variant:
+  name: public_url_start
+  source_of_url_hints: actual search receipts in idea_lut_20260907T105509_5ac81e
+  previous_run_status: protocol_exhausted
+  fresh_invocation: true
+  previous_budget_reset: false
+  interpretation: Same method goal with two public starting URLs; not an unseeded
+    literature-discovery benchmark.

--- a/docs/idea_live_review_20260907.md
+++ b/docs/idea_live_review_20260907.md
@@ -267,3 +267,34 @@ arxiv_search、web_search、fetch_sources，并使用每轮独立的 Memory 与�
 不读取上传文件，不静默更改旧 run 的输入/工具指纹；旧范围须新建评测。
 新范围的准备检查没有发送请求；26 项相关真实上下文/文件/拒绝请求检查通过，
 涉及 271 个源文件的 strict mypy 通过。实际新的模型结果另行记录。
+
+### 公开文献范围的真实失败与协议修复（11:07 UTC）
+
+run `idea_lut_20260907T105509_5ac81e` 使用 clean source `1d5e664`
+（GitHub `2dc3157`），实际运行 686.39 秒：14 次模型请求/响应/SDK 尝试，
+9 次工具/Observation，5 次格式错误触及 4 次允许修复的上限，最终 protocol_exhausted。
+未形成有效候选、未进行 schema/material 校验或 Reflection，不能称通过。
+已报告完整 152907 tokens；没有私有项目输入，也没有重复被审批阻止的旧请求。
+
+工具为一次空 Memory 查询、四次 arXiv 查询、一次空 web_search、三次 PDF 阅读。
+共检索到 11 个不同来源，实际下载两篇 PDF：Gradient-Adaptive Spline-Interpolated
+LUT Methods（5215358 字节）及 Free-Knots KAN（2442172 字节）。第一次样条 LUT
+节选不足后，Agent 自主从第 4 页起补读缓存文件；不是再次网络下载。
+模型多次连写两个 JSON、附带解释或多余括号，原始输出完整保留在 trace。
+
+发现协议修复仅回传错误位置，没有回传尚未解析的长方案，导致重新生成风险。
+新实现将完整可见原稿标为不可信数据，与旧候选、未解决审查意见一起保留；
+仍只执行模型重新输出且严格校验通过的单个动作，不由宿主猜测/补齐 JSON。
+超过输入预算明确失败，不静默截掉原稿。16 项相关检查和 strict mypy 通过。
+请求已使用官方文档的 response_format=json_object；仍保留本地严格校验，
+不能把该参数当作实测格式成功的保证。接口参考：
+https://docs.bigmodel.cn/cn/guide/capabilities/struct-output 。
+
+审计脚本另修复固定读取 v1 的问题：按 summary 记录的版本读取并验证路径；
+记录的 v2 缺失时不回退 v1。9 项相关检查通过，实际旧 run 的 v2 已正确审计。
+其独立方法审查拒绝仍保留，不因结构/材料审计通过而升级结论。
+
+下一变体 `idea_2d_lut_public_urls_real.yaml` 使用同一方法目标与同一预算，
+将本轮实际发现的两篇公开论文链接作为起点；Agent 仍须通过工具核对、读取、
+比较并生成方案。它是单独的 URL 调研评测，不冒充无预置线索的文献发现测试，
+不更改或重置本轮失败的原始状态和预算。

--- a/docs/idea_live_review_20260907.md
+++ b/docs/idea_live_review_20260907.md
@@ -298,3 +298,25 @@ https://docs.bigmodel.cn/cn/guide/capabilities/struct-output 。
 将本轮实际发现的两篇公开论文链接作为起点；Agent 仍须通过工具核对、读取、
 比较并生成方案。它是单独的 URL 调研评测，不冒充无预置线索的文献发现测试，
 不更改或重置本轮失败的原始状态和预算。
+
+### 当前实际阻塞：智谱账户错误 1113（11:16 UTC）
+
+URL 变体 run `idea_lut_20260907T111009_db0f44`（clean source `f190ebe`，
+GitHub `dda5f2a`）的首个请求两次返回 HTTP 429。旧诊断仅记录 HTTP 状态，
+无法区分短期限流和账户问题。已增加限长业务错误码与 Retry-After 的提取，
+不保存错误正文、请求头或凭证；账户/套餐/额度错误停止重试。
+Retry-After 超过当前请求的退避预算时明确延后，不提前重试或暗中延长总超时。
+30 项 provider/超时相关检查通过，含真实 SDK 连接拒绝。
+
+约 5 分钟后，用 clean source `f1c6da8` 对同一 invocation 做一次受控续跑，
+收到真实 `RateLimitError:status=429:code=1113`。智谱官方将 1113 定义为账户欠费：
+https://docs.bigmodel.cn/cn/api/api-code 。新分类器本次只尝试一次便停止，
+没有再重试该账户错误、换 Key/模型或绕过服务限制。
+累计 2 次模型请求、0 次模型响应、3 次 SDK 尝试、0 次工具，实际运行 40.20 秒。
+用量未知，不能将未收到的 token 统计写成免费调用。原输入、计数、事件前缀及
+续跑前 checkpoint 的哈希全部通过审计。最后一个 SDK 错误也会进入 CLI 和派生审计报告。
+
+**当前仍未达到 Idea Agent 的最终可用验收。** 最近一次完整研究测试停在格式校验，
+新的带原稿修复尚待实际模型验证，当前真实续测被账户错误 1113 阻断。
+工程修复、原始失败证据与可恢复 checkpoint 均保留；恢复账户额度后可在同一
+URL 变体的 checkpoint 上继续，旧失败 run 不改成通过。

--- a/scripts/audit_idea_run.py
+++ b/scripts/audit_idea_run.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 from collections import Counter
 from pathlib import Path
 from typing import Any
@@ -18,6 +19,23 @@ from app.harness.agent_loop.trace import atomic_json, audit_trace, digest
 from app.harness.schema.frontmatter_parser import parse
 from app.harness.schema.validator import validate_document
 from scripts.idea_live_resume import audit_resumptions
+
+
+def recorded_proposal(root: Path, summary: dict[str, Any]) -> Path:
+    """Audit the recorded version, never substitute an earlier successful draft."""
+    raw = summary.get("proposal_path")
+    if raw is None:
+        return root / "idea" / "idea_proposal.v1.md"
+    if not isinstance(raw, str) or not raw:
+        raise ValueError("proposal_path must name a recorded proposal file")
+    path = Path(raw)
+    if not path.is_absolute():
+        path = root / path
+    path = path.resolve()
+    if (path.parent != (root / "idea").resolve()
+            or not re.fullmatch(r"idea_proposal\.v[1-9][0-9]*\.md", path.name)):
+        raise ValueError("recorded proposal must stay in this run's versioned idea directory")
+    return path
 
 
 def audit_run(root: Path) -> dict[str, Any]:
@@ -33,7 +51,7 @@ def audit_run(root: Path) -> dict[str, Any]:
     events = [json.loads(line) for line in (trace_root / "events.jsonl").read_text().splitlines()]
     observations = state["history"]
     inventory = evidence_inventory(observations)
-    proposal = root / "idea" / "idea_proposal.v1.md"
+    proposal = recorded_proposal(root, summary)
     resumptions, errors = audit_resumptions(root, trace_root)
     schema_valid = False
     material_valid = False
@@ -88,6 +106,7 @@ def audit_run(root: Path) -> dict[str, Any]:
                for row in inventory["reads"]]
     return {
         "run_id": summary["run_id"], "source_commit": request["source_commit"], "source_tree": request["source_tree"],
+        "audited_proposal": str(proposal),
         "source_resumptions": resumptions,
         "recorded_status": summary["status"], "loop_status": state["status"], "pending": state["pending"],
         "audit_passed": not errors, "errors": errors, "trace_consistent": audit["consistent"],

--- a/scripts/audit_idea_run.py
+++ b/scripts/audit_idea_run.py
@@ -115,6 +115,7 @@ def audit_run(root: Path) -> dict[str, Any]:
         "scientific_validated": False, "project_ready": False, "simulation_executed": False,
         "duration_seconds": summary.get("duration_seconds"), "counts": state["counts"],
         "sdk_attempt_failures": sum(e["kind"] == "sdk_attempt_failed" for e in events),
+        "provider_error": audit.get("provider_error"),
         "usage": state["usage"], "recorded_usage_complete": state["usage_complete"],
         "usage_complete": bool(state["usage_complete"] and state["pending"] != "model"
                                and not any(e["kind"] == "sdk_attempt_failed" for e in events)),
@@ -167,6 +168,8 @@ def render_report(report: dict[str, Any]) -> str:
         pages = ", ".join(str(p["page"]) + ("（节选截断）" if p.get("truncated") else "") for p in row["pages"])
         lines.append(f"- {row['title']}：可见页 {pages}；理由：{row['reason']}。")
     lines.extend(["", "## 阻塞或限制", ""])
+    if report.get("provider_error"):
+        lines.append(f"- 最后一次 SDK 尝试的错误：`{report['provider_error']}`。")
     lines.extend(f"- {error}" for error in report["errors"])
     lines.extend(f"- {limit}" for limit in report["limits"])
     return "\n".join(lines) + "\n"

--- a/scripts/run_idea_lut_live.py
+++ b/scripts/run_idea_lut_live.py
@@ -192,6 +192,7 @@ async def _run(args: argparse.Namespace, root: Path) -> int:
             summary["counts"] = audit["facts"]["counts"]
             summary["usage"] = audit["facts"]["usage"]
             summary["usage_complete"] = audit["facts"]["usage_complete"]
+            summary["provider_error"] = audit.get("provider_error")
             checkpoint = trace_root / "checkpoint.json"
             if checkpoint.exists():
                 state = json.loads(checkpoint.read_text())


### PR DESCRIPTION
Real Idea testing exposed three concrete recovery failures: malformed long output was discarded from the next model input; the headless audit always opened v1 after a recorded v2 revision; and HTTP 429 logs hid the provider's business code.

Preserve the complete rejected visible output as untrusted repair data alongside the candidate and unresolved review issues. Continue to require one strictly valid JSON action; never guess or repair the answer on the host. Input overflow remains explicit. Audit the exact recorded proposal version and reject missing/outside/unversioned paths instead of falling back to an older draft.

Record only bounded provider error codes and parsed Retry-After, excluding response messages and auth data. Distinguish non-retryable account/quota errors from transient 429s; defer retries when the server's minimum delay exceeds the configured call budget. Expose the final SDK failure in CLI and derived audit output.

Add a separately labeled public-URL evaluation scenario using two sources actually discovered in the prior run. It does not replace or reset the failed unseeded run. Document real outcomes, source identities, and the current external provider block without claiming Idea acceptance.

Validation: 16 protocol/context checks, 9 version/resumption checks, and the latest 35 provider/diagnostic/version/resumption checks passed (overlapping groups, not additive). Strict Python 3.11 typing passed. Actual unseeded run: 14 model requests/responses, 9 tools, 11 discovered sources, 2 PDFs, failed protocol budget. The subsequent real continuation verified a terminal provider account error stops after one SDK attempt. Offline restoration to a different directory preserved the original inputs, two requests/three attempts and source journals without API calls. No model/tool/service substitutes were used.