### PR TITLE
Fix native candidate formatting and preserve real research revision evidence

### DIFF
--- a/backend/app/agents/base.py
+++ b/backend/app/agents/base.py
@@ -189,6 +189,11 @@ class BaseAgent(ABC):
 
     async def validate_candidate(self, request: RunRequest, text: str,
                                  observations: list[dict[str, Any]]) -> list[str]:
+        if self.loop_policy.protocol == "native_tools" and not text.startswith("---\n"):
+            return ["/format: the first four characters must be --- followed by a newline. "
+                    "Remove ALL leading explanations, JSON wrappers, and Markdown code fences. "
+                    "A schema field inside a fenced block is not frontmatter. Return only the complete raw "
+                    "Markdown document, beginning with its YAML frontmatter; preserve the existing content."]
         validation = validate_document(text, expected_schema=self.output_schema)
         errors = [f"{error.path}: {error.message}" for error in validation.errors]
         if validation.valid:

--- a/backend/app/harness/agent_loop/context.py
+++ b/backend/app/harness/agent_loop/context.py
@@ -29,7 +29,7 @@ def compact(value: Any, chars: int) -> Any:
 
 def pack_context(
     pinned: list[Message], history: list[dict[str, Any]], feedback: str,
-    candidate: str, *, budget: int, observation_chars: int,
+    candidate: str, *, budget: int, observation_chars: int, native: bool = False,
 ) -> tuple[list[Message], dict[str, Any]]:
     required = list(pinned)
     if history:
@@ -39,7 +39,7 @@ def pack_context(
                   for item in history]
         required.append(Message(role="user", content="[untrusted action receipt index; not full source content]\n" + canonical(ledger)))
     if candidate:
-        required.append(Message(role="assistant", content=canonical({"candidate": candidate})))
+        required.append(Message(role="assistant", content=candidate if native else canonical({"candidate": candidate})))
     if feedback:
         required.append(Message(role="user", content="[host validation/review feedback]\n" + feedback))
     if token_upper_bound(required) > budget:

--- a/backend/app/harness/agent_loop/executor.py
+++ b/backend/app/harness/agent_loop/executor.py
@@ -161,7 +161,8 @@ class NativeAgentLoop:
             phase = state["next_phase"]
             counts["protocol_repairs"] += 1
             state["phase_efforts"][phase] = plan["reasoning_effort"]
-            state["feedback"] = plan["feedback"]
+            state["feedback"] = (plan["feedback"].replace("JSON response", "Markdown document beginning with YAML frontmatter, without preamble or code fences")
+                                 if native and state["next_phase"] != "reflect" else plan["feedback"])
             state["pending"] = None
             state["status"] = "running"
             state["last_model_error"] = None
@@ -196,7 +197,7 @@ class NativeAgentLoop:
                     feedback += "\nTool budget exhausted. Return a final grounded document or explicit evidence gaps."
                 messages, manifest = pack_context(
                     pinned + extra, state["history"], feedback, state["candidate"],
-                    budget=p.input_token_budget - tool_schema_budget, observation_chars=p.observation_chars,
+                    budget=p.input_token_budget - tool_schema_budget, observation_chars=p.observation_chars, native=native,
                 )
                 manifest["tool_schema_upper_bound_tokens"] = tool_schema_budget
                 manifest["total_input_upper_bound_tokens"] = manifest["estimated_upper_bound_tokens"] + tool_schema_budget

--- a/backend/tests/unit/test_native_tool_protocol.py
+++ b/backend/tests/unit/test_native_tool_protocol.py
@@ -74,3 +74,20 @@ def test_native_idea_prompt_has_no_legacy_json_instruction() -> None:
     text = '\n'.join(m.content for m in agent._messages_for_context(request,context,purpose='contract'))
     assert 'final.metadata' not in text and 'final.body' not in text
     assert 'YAML frontmatter' in text
+
+
+def test_native_candidate_is_not_rewrapped_as_json() -> None:
+    candidate = '---\nschema: proposal.v1\n---\n# Draft'
+    messages, _ = pack_context([Message('system','task')], [], '', candidate,
+                               budget=4000, observation_chars=512, native=True)
+    assert messages[-1].content == candidate
+
+
+@pytest.mark.asyncio
+async def test_fenced_frontmatter_gets_actionable_format_feedback() -> None:
+    from app.agents.idea.agent import IdeaAgent
+    from app.agents.base import RunRequest
+    errors = await IdeaAgent().validate_candidate(RunRequest(project='pimc',user_request='test'),
+        'Explanation\n```markdown\n---\nschema: proposal.v1\n---\ntext\n```', [])
+    assert len(errors) == 1 and errors[0].startswith('/format:')
+    assert 'code fences' in errors[0]

--- a/docs/evaluation/idea_react_20260907/external_review.md
+++ b/docs/evaluation/idea_react_20260907/external_review.md
@@ -1,0 +1,18 @@
+# Independent review of the unaccepted Idea draft
+
+The previous run failed format validation. This is revision feedback, not a scientific acceptance certificate. Use only the already retrieved public papers and receipts. Do not invent experiments or new source readings. Return a compact complete document, no introductory explanation or fences. Keep all definitions in metadata and body under 600 Chinese characters.
+
+Resolve these concrete defects throughout the document, not by adding a contradictory disclaimer:
+
+1. C2 regularity alone does not justify fourth-order cubic-spline approximation. State adequate derivative/mesh assumptions or remove the order guarantee. An asymptotic rate does not establish a finite-budget accuracy gain.
+2. For clamped cubic B-splines specify zero-denominator terms in Cox-de Boor, the right endpoint basis convention, and dimensionally consistent coordinates (normalized coordinates vs physical Amax knots).
+3. In bilinear interpolation floor at the maximum input leads to an out-of-range i+1. Define the boundary cell index and its interpolation fraction explicitly.
+4. Normalized eps+softplus gaps do not ensure a fixed minimum normalized interval: the denominator can become arbitrarily large. Address representable numerical ordering, finite extreme logits and fixed endpoints; do not assert eps is the final normalized lower bound.
+5. Unconstrained real coefficients do not ensure nonnegative gain. Correct the sign/phase contract and define x_ref from provided inputs or declare it a separate required input. Handle zero output and reference phase explicitly.
+6. The alternative N=17 uses N*N with global N=16, contradicting shape [17,17] and count 289. Use consistent distinct variables and count all trainables.
+7. For fixed degree and M=12 control points, the knot-vector length and interior-knot count are constrained. The G=9 vs G=5 ablation cannot hold those unchanged. Define mathematically valid controls and distinguish equal-control-point vs equal-total-parameter comparisons.
+8. Sampling a baseline at control-point locations is not identical to least-squares projection. Give one reproducible initialization: sampling locations, target, solver and explicit fit-error handling. Do not promise a no-worse initialization for non-nested spaces.
+9. A theorem about effective knots in a composed KAN is not automatically a theorem for a single 2D tensor-product LUT. Separate each paper's findings from this proposal's transfer hypotheses.
+10. Keep one metric direction and one exhaustive decision rule; specify the statistical resampling unit without treating correlated blocks as independent replicates.
+
+The proposal may remain a falsifiable method hypothesis. No production baseline, dataset or GPU has been supplied; no performance or novelty claim is experimentally established.

--- a/scripts/repair_idea_candidate_live.py
+++ b/scripts/repair_idea_candidate_live.py
@@ -1,0 +1,82 @@
+"""Real Idea revision using a prior audited public research run, without new research."""
+from __future__ import annotations
+import argparse
+import asyncio
+import json
+import subprocess
+from dataclasses import replace
+from pathlib import Path
+from typing import Any
+from loguru import logger
+from app.agents.idea.agent import IdeaAgent
+from app.harness.agent_loop import LoopInput, NativeAgentLoop, AgentLoopPolicy
+from app.harness.agent_loop.trace import audit_trace, atomic_json
+from app.harness.llm.model_registry import get_agent_config
+from app.harness.tools.registry import ToolContext, get_registry
+from scripts.run_idea_lut_live import evaluation_request
+
+
+async def run(prior: Path, target: Path, review: Path) -> None:
+    initial = json.loads((prior/'input'/'request.json').read_text())
+    prior_summary = json.loads((prior/'summary.json').read_text())
+    trace = Path(prior_summary['trace_root'])
+    if not audit_trace(trace)['consistent']:
+        raise ValueError('prior evidence trace must be consistent')
+    state = json.loads((trace/'checkpoint.json').read_text())
+    if not state['candidate']:
+        raise ValueError('prior run has no candidate to revise')
+    target.mkdir(parents=True,exist_ok=False)
+    scenario = initial['scenario']
+    request = evaluation_request(scenario,target)
+    request.user_request += '\nThis is a revision using the supplied, previously audited public research. Do not repeat retrieval. Resolve the external review and output only the corrected complete document.'
+    cfg = get_agent_config('idea')
+    agent = IdeaAgent(agent_config=replace(cfg,tools=()))
+    context = await agent.build_context(request)
+    context.upstream['previous_unaccepted_candidate'] = state['candidate']
+    context.upstream['external_review'] = review.read_text()
+    receipts=[]
+    for observation in state['history']:
+        if observation['tool']=='search.fetch_sources' and observation['ok']:
+            for source in observation['output'].get('sources',[]):
+                receipts.append({key: source.get(key) for key in ('title','url','sha256','download_path','read_receipt','visible_pages')})
+    # All visible excerpts are prior real tool results, not authored observations.
+    unique: dict[str, dict[str, Any]] = {}
+    for receipt in receipts:
+        identity = receipt['sha256']
+        record = unique.setdefault(identity, {**receipt, 'visible_pages': {}, 'read_receipts': [], 'full_document_read': False})
+        record['read_receipts'].append(receipt['read_receipt'])
+        for page in receipt['visible_pages']:
+            old = record['visible_pages'].get(page['page'])
+            if old is None or len(page['text']) > len(old['text']):
+                record['visible_pages'][page['page']] = page
+    for record in unique.values():
+        record['visible_pages'] = list(record['visible_pages'].values())
+    context.upstream['prior_public_read_receipts'] = json.dumps(list(unique.values()),ensure_ascii=False)
+    provider, model = agent._select_provider()
+    model.request_timeout_seconds=300
+    model.max_retries=0
+    model.max_tokens=16384
+    async def validate(text: str, observations: list[dict[str, Any]]) -> list[str]:
+        return await agent.validate_candidate(request,text,state['history']+observations)
+    atomic_json(target/'source.json',{'source_commit':subprocess.check_output(['git','rev-parse','HEAD'],text=True).strip(),
+        'prior_run':str(prior),'prior_source_commit':initial['source_commit'],'review':review.read_text(),
+        'scope':'candidate revision using prior audited research; not a new end-to-end research run'})
+    result=await NativeAgentLoop().run(LoopInput(
+        messages=agent._messages_for_context(request,context,purpose='evidence_bound_revision'),
+        provider=provider,config=model,registry=get_registry(),tools=(),
+        tool_context=ToolContext(target.name,'pimc','idea'),
+        policy=AgentLoopPolicy(protocol='native_tools',mode='react',max_model_calls=4,max_tool_steps=0,
+                               max_validation_repairs=3,input_token_budget=128000),
+        trace_root=target/'trace',validate=validate))
+    (target/'candidate.md').write_text(result.text)
+    atomic_json(target/'summary.json',{'status':result.status,'counts':result.counts,
+                                     'scientific_validated':False,'prior_evidence_run':str(prior)})
+    logger.info('IDEA_REVISION_RESULT status={} counts={} output={}',result.status,result.counts,target)
+
+if __name__=='__main__':
+    parser=argparse.ArgumentParser()
+    parser.add_argument('prior',type=Path)
+    parser.add_argument('target',type=Path)
+    parser.add_argument('review',type=Path)
+    args=parser.parse_args()
+    asyncio.run(run(args.prior.resolve(),args.target.resolve(),args.review.resolve()))


### PR DESCRIPTION
Native research reached a candidate but exhausted validation retries on wrapping and format errors. This change keeps native candidate context as raw Markdown, gives actionable frontmatter diagnostics, and fixes truncated-output feedback. Adds an evidence-bound real-provider revision script and records independent scientific review. The original full research run failed; the subsequent two-call revision passed existing structural/material validation but still has scientific defects. Targeted 66 tests and strict mypy passed. No mock execution.